### PR TITLE
[FEAT] Configure Slash Command

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "development" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "development" ]
   schedule:
     - cron: '0 12 * * 1'
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,7 +10,7 @@
 name: 'Dependency review'
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "development" ]
 
 # If using a dependency submission action in this workflow this permission will need to be set to:
 #

--- a/README.md
+++ b/README.md
@@ -33,3 +33,14 @@ Usage: `/help`
 Description: Shows all commands available with their respective description
 
 Cooldown: `1 minute`
+
+#### Configure - Slash Command
+
+Usage:\
+`/configure enable-system`\
+`/configure disable-system`\
+`/configure system <Req. Options> [Opt. Options]`
+
+Description: Manage the configuration data that Mod Tickets will use
+
+Cooldown: `2 minutes`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Mod Tickets
 
+![CodeQL analysis](https://github.com/github/docs/actions/workflows/codeql.yml/badge.svg)
+
 Mod Tickets is a discord bot (or App) generated using the TypeScript reciple template
 
 > This application was generated using the [`create-reciple`](https://npm.im/create-reciple) template. Please show them some love as this project wouldn't have been easy without them

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "start": "reciple -c reciple.mjs",
     "build:start": "bun run build && reciple -c reciple.mjs",
     "dev": "nodemon --ext ts,mts,cts,json --ignore ./modules --exec \"bun run build && reciple -c reciple.test.mjs\" --signal SIGHUP",
-    "flush:logs": "rimraf ./logs/*.log.gz -g"
+    "flush:logs:full": "rimraf ./logs/**/*.log.gz -g",
+    "flush:logs:prod": "rimraf ./logs/production/*.log.gz -g",
+    "flush:logs:test": "rimraf ./logs/production/*.log.gz -g"
   },
   "dependencies": {
     "@prisma/client": "^5.13.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,34 +15,36 @@ datasource db {
 
 model TicketConfig {
   id       String @id @default(auto()) @map("_id") @db.ObjectId
-  guild_id  String  @unique
+  guild_id String @unique
 
-  create_channel_id String
-  transcripts_channel_id    String
-  ticket_parent_channel_id  String
+  create_channel_id        String
+  transcripts_channel_id   String
+  ticket_parent_channel_id String
 
-  ticket_type  TicketType
+  ticket_create_type TicketCreateType
 
-  embed_title   String?
+  embed_title       String?
   embed_description String?
+
+  enabled Boolean @default(true)
 }
 
 model Tickets {
-    id       String @id @default(auto()) @map("_id") @db.ObjectId
-    guild_id    String
-    ticket_channel_id   String
-    ticket_id   String
+  id                String @id @default(auto()) @map("_id") @db.ObjectId
+  guild_id          String
+  ticket_channel_id String
+  ticket_id         String
 
-    creator_id  String
-    member_ids  String[]
+  creator_id String
+  member_ids String[]
 
-    closed  Boolean  @default(false)
-    locked  Boolean @default(false)
+  closed Boolean @default(false)
+  locked Boolean @default(false)
 }
 
-enum TicketType {
-    Button
-    ButtonModal
-    Command
-    CommandModal
+enum TicketCreateType {
+  Button
+  ButtonModal
+  Command
+  CommandModal
 }

--- a/reciple.mjs
+++ b/reciple.mjs
@@ -52,7 +52,7 @@ export const config = {
         disableLogPrefix: false,
         logToFile: {
             enabled: true,
-            logsFolder: './logs',
+            logsFolder: './logs/production',
             file: 'latest.log'
         }
     },

--- a/reciple.test.mjs
+++ b/reciple.test.mjs
@@ -52,7 +52,7 @@ export const config = {
         disableLogPrefix: false,
         logToFile: {
             enabled: true,
-            logsFolder: './logs',
+            logsFolder: './logs/test',
             file: 'latest.log'
         }
     },

--- a/src/Commands/Configure.ts
+++ b/src/Commands/Configure.ts
@@ -1,6 +1,6 @@
 import { SlashCommandBuilder } from "reciple";
 import { BaseModule } from "../BaseModule.js";
-import { CategoryChannel, ChannelType, ChatInputCommandInteraction, EmbedBuilder, PermissionFlagsBits, TextChannel } from "discord.js";
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, CategoryChannel, ChannelType, ChatInputCommandInteraction, EmbedBuilder, PermissionFlagsBits, TextChannel } from "discord.js";
 import MessageUtility from "../Utils/MessageUtility.js";
 import { prisma } from "../Prisma.js";
 import { TicketCreateType } from "@prisma/client";
@@ -232,7 +232,7 @@ export class ConfigureCmd extends BaseModule {
         const createChannel = options.getChannel('ticket-create-channel', true) as TextChannel
         const parentChannel = options.getChannel('ticket-parent-channel', true) as CategoryChannel
         const transcriptsChannel = options.getChannel('transcripts-channel', true) as TextChannel
-        const toResolveCreateType = options.getString('ticket-create-tye', true) as 'button' | 'button-modal' | 'command' | 'command-modal';
+        const toResolveCreateType = options.getString('ticket-create-type', true) as 'button' | 'button-modal' | 'command' | 'command-modal';
         
         const embedTitle = options.getString('embed-title', false);
         const embedDescription = options.getString('embed-description', false);
@@ -284,6 +284,26 @@ export class ConfigureCmd extends BaseModule {
                     .setDescription(MessageUtility.createSuccessMessage('Successfully sent the configuration data to the database'))
             ]
         })
+
+        if (createType === 'Button' || createType === 'ButtonModal') {
+            await createChannel.send({
+                embeds: [
+                    new EmbedBuilder()
+                        .setColor(MessageUtility.embedColourDefault)
+                        .setTitle(embedTitle ?? "Create a Ticket")
+                        .setDescription(embedDescription ?? "Create a ticket by clicking one of the buttons below")
+                ],
+                components: [
+                    new ActionRowBuilder<ButtonBuilder>().setComponents(
+                        new ButtonBuilder()
+                            .setCustomId('ticket-create-button')
+                            .setLabel('Click for support')
+                            .setStyle(ButtonStyle.Primary)
+                            .setEmoji('🎫')
+                )]
+            })
+        }
+
         return;
     }
 }

--- a/src/Commands/Configure.ts
+++ b/src/Commands/Configure.ts
@@ -287,3 +287,5 @@ export class ConfigureCmd extends BaseModule {
         return;
     }
 }
+
+export default new ConfigureCmd();

--- a/src/Commands/Configure.ts
+++ b/src/Commands/Configure.ts
@@ -1,0 +1,289 @@
+import { SlashCommandBuilder } from "reciple";
+import { BaseModule } from "../BaseModule.js";
+import { CategoryChannel, ChannelType, ChatInputCommandInteraction, EmbedBuilder, PermissionFlagsBits, TextChannel } from "discord.js";
+import MessageUtility from "../Utils/MessageUtility.js";
+import { prisma } from "../Prisma.js";
+import { TicketCreateType } from "@prisma/client";
+
+export class ConfigureCmd extends BaseModule {
+    public versions: string | string[] = "^8";
+
+    public onStart(): string | boolean | Error | Promise<string | boolean | Error> {
+        this.commands = [
+            new SlashCommandBuilder()
+                .setName('configure')
+                .setDescription('Manage the configuration data that Mod Tickets will use')
+                .addSubcommand(enable => enable
+                    .setName('enable-system')
+                    .setDescription('If the ticketing system is disabled, you can re-enable it')
+                )
+                .addSubcommand(disable => disable
+                    .setName('disable-system')
+                    .setDescription('If the ticketing system is enabled, you can disable it')
+                )
+                .addSubcommand(system => system
+                    .setName('system')
+                    .setDescription('The configuration data can been managed here')
+                    .addChannelOption(createChannel => createChannel
+                        .setName('ticket-create-channel')
+                        .setDescription('The text channel where users can create a ticket')
+                        .addChannelTypes(ChannelType.GuildText)
+                        .setRequired(true)
+                    )
+                    .addChannelOption(parentChannel => parentChannel
+                        .setName('ticket-parent-channel')
+                        .setDescription('A category channel where ticket channels are made. Not to be confused with `ticket-create-channel`')
+                        .addChannelTypes(ChannelType.GuildCategory)
+                        .setRequired(true)
+                    )
+                    .addChannelOption(transcriptsChannel => transcriptsChannel
+                        .setName('transcripts-channel')
+                        .setDescription('The text channel where a copy of the messages sent in a ticket channel are sent to')
+                        .addChannelTypes(ChannelType.GuildText)
+                        .setRequired(true)
+                    )
+                    .addStringOption(createType => createType
+                        .setName('ticket-create-type')
+                        .setDescription('The method Mod Tickets will allow users to use')
+                        .addChoices(
+                            { name: "Button", value: "button" },
+                            { name: "Button + Modal", value: "button-modal" },
+                            { name: "Command (Create ticket embed won't be used)", value: "command" },
+                            { name: "Command + Modal (Create ticket embed won't be used)", value: "command-modal" }
+                        )
+                        .setRequired(true)
+                    )
+                    .addStringOption(embedTitle => embedTitle
+                        .setName('embed-title')
+                        .setDescription('The title of the embed when the `ticket-create-type` uses on of the button methods')
+                        .setMaxLength(256)
+                        .setRequired(false)
+                    )
+                    .addStringOption(embedDescription => embedDescription
+                        .setName('embed-description')
+                        .setDescription('The description of the embed when the `ticket-create-type` uses on of the button methods')
+                        .setMaxLength(2000)
+                        .setRequired(false)
+                    )
+                )
+                .setCooldown(2 * 60 * 1000)
+                .setDMPermission(false)
+                .setRequiredMemberPermissions(PermissionFlagsBits.ManageChannels)
+                .setExecute(async ({ interaction }) => {
+                    if (!interaction.inCachedGuild()) {
+                        await interaction.reply({
+                            embeds: [
+                                new EmbedBuilder()
+                                    .setColor(MessageUtility.embedColourError)
+                                    .setAuthor({ name: "Error" })
+                                    .setDescription(MessageUtility.createErrorMessage(MessageUtility.ErrorMessages.NOT_CACHED_GUILD))
+                            ],
+                            ephemeral: true,
+                        })
+                        return;
+                    }
+
+                    await interaction.deferReply({ ephemeral: true });
+
+                    switch (interaction.options.getSubcommand(true) as 'system' | 'enable-system' | 'disable-system') {
+                        case 'enable-system': {
+                            return await this.HandleEnableSystem(interaction as never as ChatInputCommandInteraction<"cached">)
+                        }
+                        case 'disable-system': {
+                            return await this.HandleDisableSystem(interaction as never as ChatInputCommandInteraction<"cached">)
+                        }
+                        case 'system': {
+                            return await this.HandleSystem(interaction as never as ChatInputCommandInteraction<"cached">)
+                        }
+                    }
+                })
+        ]
+
+        return true;
+    }
+
+    private async HandleEnableSystem(interaction: ChatInputCommandInteraction<"cached">): Promise<void> {
+        const ticketConfig = await prisma.ticketConfig.findUnique({ where: { guild_id: interaction.guild.id }});
+        if (!ticketConfig) {
+            await interaction.editReply({
+                embeds: [
+                    new EmbedBuilder()
+                        .setColor(MessageUtility.embedColourError)
+                        .setAuthor({ name: "Error" })
+                        .setDescription(`
+                        ${MessageUtility.createErrorMessage('The configuration was unable to be fetched from the database.')}
+
+                        ${MessageUtility.createTipMessage('Try running`/configure system` to add configuration data if you never did')}
+                        `)
+                ]
+            })
+            return;
+        }
+
+        if (ticketConfig.enabled) {
+            await interaction.editReply({
+                embeds: [
+                    new EmbedBuilder()
+                        .setColor(MessageUtility.embedColourSuccess)
+                        .setAuthor({ name: "Success?" })
+                        .setDescription(`
+                        ${MessageUtility.createSuccessMessage('Successfully enabled the ticketing system')}
+
+                        😜 Looks like the system was already enabled. But hey, you achieved your goal anyways
+                        `)
+                ]
+            })
+            return;
+        }
+
+        try {
+            await prisma.ticketConfig.update({
+                where: { guild_id: interaction.guild.id },
+                data: { enabled: true }
+            })
+        } catch (err) {
+            await interaction.editReply({
+                embeds: [
+                    new EmbedBuilder()
+                        .setColor(MessageUtility.embedColourError)
+                        .setAuthor({ name: "Error" })
+                        .setDescription(MessageUtility.createErrorMessage(MessageUtility.ErrorMessages.DATABASE_ERROR))
+                ]
+            })
+            return;
+        }
+
+        await interaction.editReply({
+            embeds: [
+                new EmbedBuilder()
+                    .setColor(MessageUtility.embedColourSuccess)
+                    .setAuthor({ name: "Success" })
+                    .setDescription(MessageUtility.createSuccessMessage("Successfully enabled the ticketing system"))
+            ]
+        })
+        return;
+    }
+
+    private async HandleDisableSystem(interaction: ChatInputCommandInteraction<"cached">): Promise<void> {
+        const ticketConfig = await prisma.ticketConfig.findUnique({ where: { guild_id: interaction.guild.id }});
+        if (!ticketConfig) {
+            await interaction.editReply({
+                embeds: [
+                    new EmbedBuilder()
+                        .setColor(MessageUtility.embedColourError)
+                        .setAuthor({ name: "Error" })
+                        .setDescription(`
+                        ${MessageUtility.createErrorMessage('The configuration was unable to be fetched from the database.')}
+
+                        ${MessageUtility.createTipMessage('Try running`/configure system` to add configuration data if you never did')}
+                        `)
+                ]
+            })
+            return;
+        }
+
+        if (!ticketConfig.enabled) {
+            await interaction.editReply({
+                embeds: [
+                    new EmbedBuilder()
+                        .setColor(MessageUtility.embedColourSuccess)
+                        .setAuthor({ name: "Success?" })
+                        .setDescription(`
+                        ${MessageUtility.createSuccessMessage('Successfully disabled the ticketing system')}
+
+                        😜 Looks like the system was already disabled. But hey, you achieved your goal anyways
+                        `)
+                ]
+            })
+            return;
+        }
+
+        try {
+            await prisma.ticketConfig.update({
+                where: { guild_id: interaction.guild.id },
+                data: { enabled: false }
+            })
+        } catch (err) {
+            await interaction.editReply({
+                embeds: [
+                    new EmbedBuilder()
+                        .setColor(MessageUtility.embedColourError)
+                        .setAuthor({ name: "Error" })
+                        .setDescription(MessageUtility.createErrorMessage(MessageUtility.ErrorMessages.DATABASE_ERROR))
+                ]
+            })
+            return;
+        }
+
+        await interaction.editReply({
+            embeds: [
+                new EmbedBuilder()
+                    .setColor(MessageUtility.embedColourSuccess)
+                    .setAuthor({ name: "Success" })
+                    .setDescription(MessageUtility.createSuccessMessage("Successfully disabled the ticketing system"))
+            ]
+        })
+        return;
+    }
+
+    private async HandleSystem(interaction: ChatInputCommandInteraction<"cached">): Promise<void> {
+        const { options, guild } = interaction;
+
+        const createChannel = options.getChannel('ticket-create-channel', true) as TextChannel
+        const parentChannel = options.getChannel('ticket-parent-channel', true) as CategoryChannel
+        const transcriptsChannel = options.getChannel('transcripts-channel', true) as TextChannel
+        const toResolveCreateType = options.getString('ticket-create-tye', true) as 'button' | 'button-modal' | 'command' | 'command-modal';
+        
+        const embedTitle = options.getString('embed-title', false);
+        const embedDescription = options.getString('embed-description', false);
+
+        const createType = toResolveCreateType.split("-").map(type => `${type.charAt(0).toUpperCase()}${type.substring(1)}`).join("") as TicketCreateType;
+
+        try {
+            await prisma.ticketConfig.upsert({
+                where: { guild_id: guild.id },
+                update: {
+                    create_channel_id: createChannel.id,
+                    ticket_parent_channel_id: parentChannel.id,
+                    transcripts_channel_id: transcriptsChannel.id,
+
+                    ticket_create_type: createType,
+
+                    embed_title: embedTitle,
+                    embed_description: embedDescription
+                },
+                create: {
+                    guild_id: guild.id,
+                    create_channel_id: createChannel.id,
+                    ticket_parent_channel_id: parentChannel.id,
+                    transcripts_channel_id: transcriptsChannel.id,
+
+                    ticket_create_type: createType,
+
+                    embed_title: embedTitle,
+                    embed_description: embedDescription
+                }
+            })
+        } catch (err) {
+            await interaction.editReply({
+                embeds: [
+                    new EmbedBuilder()
+                        .setColor(MessageUtility.embedColourError)
+                        .setAuthor({ name: "Error" })
+                        .setDescription(MessageUtility.createErrorMessage(MessageUtility.ErrorMessages.DATABASE_ERROR))
+                ]
+            })
+            return;
+        }
+
+        await interaction.editReply({
+            embeds: [
+                new EmbedBuilder()
+                    .setColor(MessageUtility.embedColourSuccess)
+                    .setAuthor({ name: "Success" })
+                    .setDescription(MessageUtility.createSuccessMessage('Successfully sent the configuration data to the database'))
+            ]
+        })
+        return;
+    }
+}

--- a/src/Commands/Configure.ts
+++ b/src/Commands/Configure.ts
@@ -23,7 +23,7 @@ export class ConfigureCmd extends BaseModule {
                 )
                 .addSubcommand(system => system
                     .setName('system')
-                    .setDescription('The configuration data can been managed here')
+                    .setDescription('The configuration data can be managed here')
                     .addChannelOption(createChannel => createChannel
                         .setName('ticket-create-channel')
                         .setDescription('The text channel where users can create a ticket')

--- a/src/Utils/AddCommandHalt.ts
+++ b/src/Utils/AddCommandHalt.ts
@@ -1,4 +1,4 @@
-import { AnyCommandBuilder, AnyCommandHaltData, CommandHaltReason, CommandPermissionsPrecondition, CommandPermissionsPreconditionTriggerDataType, CommandType, RecipleModuleLoadData, RecipleModuleStartData } from "reciple";
+import { AnyCommandBuilder, AnyCommandHaltData, CommandHaltReason, CommandPermissionsPrecondition, CommandPermissionsPreconditionTriggerDataType, CommandType, RecipleModuleLoadData } from "reciple";
 import { BaseModule } from "../BaseModule.js";
 import { codeBlock, EmbedBuilder, inlineCode, PermissionsBitField, time, TimestampStyles } from "discord.js";
 import MessageUtility from "./MessageUtility.js";

--- a/src/Utils/MessageUtility.ts
+++ b/src/Utils/MessageUtility.ts
@@ -20,6 +20,11 @@ export class MessageUtility extends BaseModule {
 	public defaultQuestionEmoji: string = '❓';
 	public defaultInfoEmoji: string = 'ℹ️';
 
+    public ErrorMessages = {
+        DATABASE_ERROR: "Oh no! Something went wrong when trying to edit the data in the database. Please try again later",
+        NOT_CACHED_GUILD: "Oh no! Something went wrong as you are not in a cached guild. Please try again later"
+    }
+
 	public createErrorMessage(message: string): string {
 		return this.createLabel(message, this.defaultErrorEmoji);
 	}


### PR DESCRIPTION
New slash command: `/configure`

Command Subcommands:
`/configure system <Req. Options> [Opt. Options]`
`/configure enable-system`
`/configure disable-system`

DM compatible: :x:
Cooldown: `2 minutes`
Required User Permissions: `ManageChannels`

## Subcommand Uses
Here is how you can use the various subcommands

### system
Description: The configuration data can been managed here
Required Options:
`ticket-create-channel` - TextChannel
`ticket-parent-channel` - CategoryChannel
`transcripts-channel` - TextChannel
`ticket-create-type` - "Button" | "ButtonModal" | "Command" | "CommandModal"

Optional Options:
`embed-title` - String. Max --> `265` chars
`embed-description` - String. Max --> `2000` chars

### enable-system
Description: If the ticketing system is disabled, you can re-enable it

### disable-system
Description: If the ticketing system is enabled, you can disable it