### PR TITLE
[FEAT]: Ticket Channel Creation support using Button methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ Mod Tickets has a range of simple features to make your ticketing experience as 
 Some example are:
 
 - Creating tickets (obviously)
+  - Using commands
+  - Using commands w/ modals
+  - Using a button (the simple one)
+  - Using a button w/ modals
 - Ticket channel locking
+  - Support for locking & unlocking
 - Transcripts
 
 ### Commands

--- a/src/Commands/Configure.ts
+++ b/src/Commands/Configure.ts
@@ -77,6 +77,7 @@ export class ConfigureCmd extends BaseModule {
                                     .setColor(MessageUtility.embedColourError)
                                     .setAuthor({ name: "Error" })
                                     .setDescription(MessageUtility.createErrorMessage(MessageUtility.ErrorMessages.NOT_CACHED_GUILD))
+                                    .setTimestamp()
                             ],
                             ephemeral: true,
                         })
@@ -110,11 +111,8 @@ export class ConfigureCmd extends BaseModule {
                     new EmbedBuilder()
                         .setColor(MessageUtility.embedColourError)
                         .setAuthor({ name: "Error" })
-                        .setDescription(`
-                        ${MessageUtility.createErrorMessage('The configuration was unable to be fetched from the database.')}
-
-                        ${MessageUtility.createTipMessage('Try running`/configure system` to add configuration data if you never did')}
-                        `)
+                        .setDescription(MessageUtility.createErrorMessage(MessageUtility.ErrorMessages.NO_TICKET_CONFIG))
+                        .setTimestamp()
                 ]
             })
             return;
@@ -131,6 +129,7 @@ export class ConfigureCmd extends BaseModule {
 
                         😜 Looks like the system was already enabled. But hey, you achieved your goal anyways
                         `)
+                        .setTimestamp()
                 ]
             })
             return;
@@ -148,6 +147,7 @@ export class ConfigureCmd extends BaseModule {
                         .setColor(MessageUtility.embedColourError)
                         .setAuthor({ name: "Error" })
                         .setDescription(MessageUtility.createErrorMessage(MessageUtility.ErrorMessages.DATABASE_ERROR))
+                        .setTimestamp()
                 ]
             })
             return;
@@ -159,6 +159,7 @@ export class ConfigureCmd extends BaseModule {
                     .setColor(MessageUtility.embedColourSuccess)
                     .setAuthor({ name: "Success" })
                     .setDescription(MessageUtility.createSuccessMessage("Successfully enabled the ticketing system"))
+                    .setTimestamp()
             ]
         })
         return;
@@ -172,11 +173,8 @@ export class ConfigureCmd extends BaseModule {
                     new EmbedBuilder()
                         .setColor(MessageUtility.embedColourError)
                         .setAuthor({ name: "Error" })
-                        .setDescription(`
-                        ${MessageUtility.createErrorMessage('The configuration was unable to be fetched from the database.')}
-
-                        ${MessageUtility.createTipMessage('Try running`/configure system` to add configuration data if you never did')}
-                        `)
+                        .setDescription(MessageUtility.createErrorMessage(MessageUtility.ErrorMessages.NO_TICKET_CONFIG))
+                        .setTimestamp()
                 ]
             })
             return;
@@ -193,6 +191,7 @@ export class ConfigureCmd extends BaseModule {
 
                         😜 Looks like the system was already disabled. But hey, you achieved your goal anyways
                         `)
+                        .setTimestamp()
                 ]
             })
             return;
@@ -210,6 +209,7 @@ export class ConfigureCmd extends BaseModule {
                         .setColor(MessageUtility.embedColourError)
                         .setAuthor({ name: "Error" })
                         .setDescription(MessageUtility.createErrorMessage(MessageUtility.ErrorMessages.DATABASE_ERROR))
+                        .setTimestamp()
                 ]
             })
             return;
@@ -221,6 +221,7 @@ export class ConfigureCmd extends BaseModule {
                     .setColor(MessageUtility.embedColourSuccess)
                     .setAuthor({ name: "Success" })
                     .setDescription(MessageUtility.createSuccessMessage("Successfully disabled the ticketing system"))
+                    .setTimestamp()
             ]
         })
         return;
@@ -271,6 +272,7 @@ export class ConfigureCmd extends BaseModule {
                         .setColor(MessageUtility.embedColourError)
                         .setAuthor({ name: "Error" })
                         .setDescription(MessageUtility.createErrorMessage(MessageUtility.ErrorMessages.DATABASE_ERROR))
+                        .setTimestamp()
                 ]
             })
             return;
@@ -282,6 +284,7 @@ export class ConfigureCmd extends BaseModule {
                     .setColor(MessageUtility.embedColourSuccess)
                     .setAuthor({ name: "Success" })
                     .setDescription(MessageUtility.createSuccessMessage('Successfully sent the configuration data to the database'))
+                    .setTimestamp()
             ]
         })
 
@@ -292,6 +295,7 @@ export class ConfigureCmd extends BaseModule {
                         .setColor(MessageUtility.embedColourDefault)
                         .setTitle(embedTitle ?? "Create a Ticket")
                         .setDescription(embedDescription ?? "Create a ticket by clicking one of the buttons below")
+                        .setTimestamp()
                 ],
                 components: [
                     new ActionRowBuilder<ButtonBuilder>().setComponents(

--- a/src/InteractionListeners/Buttons/TicketCreateBtn.ts
+++ b/src/InteractionListeners/Buttons/TicketCreateBtn.ts
@@ -1,0 +1,175 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, CacheType, channelMention, ChannelType, EmbedBuilder, ModalBuilder, PermissionFlagsBits, TextInputBuilder, TextInputStyle } from "discord.js";
+import { BaseModule } from "../../BaseModule.js";
+import MessageUtility from "../../Utils/MessageUtility.js";
+import { prisma } from "../../Prisma.js";
+import { InteractionListenerType } from "reciple-interaction-events";
+import Helper from "../../Utils/Helper.js";
+
+export class TicketCreateBtn extends BaseModule {
+    public versions: string | string[] = "^8";
+
+    public onStart(): string | boolean | Error | Promise<string | boolean | Error> {
+        this.interactionListeners = [
+            {
+                type: InteractionListenerType.Button,
+                customId: 'ticket-create-button',
+                // FIXME - Add a system to add halts to interaction listeners
+                // cooldown: 5 * 60 * 1000,
+                requiredBotPermissions: PermissionFlagsBits.ManageChannels,
+                execute: async (interaction) => {
+                    return await this.HandleExecute(interaction as never as ButtonInteraction<CacheType>);
+                }
+            }
+        ]
+        return true;
+    }
+
+    public async HandleExecute(interaction: ButtonInteraction<CacheType>): Promise<void> {
+        if (!interaction.inCachedGuild()) {
+            await interaction.reply({
+                embeds: [
+                    new EmbedBuilder()
+                        .setColor(MessageUtility.embedColourError)
+                        .setAuthor({ name: "Error" })
+                        .setDescription(MessageUtility.createErrorMessage(MessageUtility.ErrorMessages.NOT_CACHED_GUILD))
+                        .setTimestamp()
+                ]
+            })
+            return;
+        }
+
+        await interaction.deferReply({ ephemeral: true });
+
+        const ticketConfig = await prisma.ticketConfig.findUnique({ where: { guild_id: interaction.guild.id } });
+
+        if (!ticketConfig) {
+            await interaction.editReply({
+                embeds: [
+                    new EmbedBuilder()
+                        .setColor(MessageUtility.embedColourError)
+                        .setAuthor({ name: "Error" })
+                        .setDescription(MessageUtility.createErrorMessage(MessageUtility.ErrorMessages.NO_TICKET_CONFIG))
+                        .setTimestamp()
+                ]
+            })
+            return;
+        }
+
+        const memberTicket = await prisma.tickets.findFirst({ where: { guild_id: interaction.guild.id, creator_id: interaction.member.id, closed: false } })
+        const memberHasOpenTicket = memberTicket === null ? false : true;
+
+        if (memberHasOpenTicket) {
+            await interaction.editReply({
+                embeds: [
+                    new EmbedBuilder()
+                        .setColor(MessageUtility.embedColourError)
+                        .setAuthor({ name: "Error" })
+                        .setDescription(MessageUtility.createErrorMessage(`You have exceeded the number of open tickets you can have at once. Please first close your ticket at ${channelMention(memberTicket!.ticket_channel_id)}`))
+                        .setTimestamp()
+                ]
+            })
+            return;
+        }
+
+        switch (ticketConfig.ticket_create_type) {
+            case 'Button': {
+                const ticketId = Helper.generateTicketId();
+                const ticketChannel = await Helper.CreateTicketChannel(interaction, ticketConfig, ticketId)
+                await ticketChannel.send({
+                    embeds: [
+                        new EmbedBuilder()
+                            .setColor(MessageUtility.embedColourDefault)
+                            .setAuthor({ name: interaction.user.username, iconURL: interaction.member.displayAvatarURL() })
+                            .setTitle(`Ticket - ${ticketId}`)
+                            .setDescription(`
+                            Thank you for contacting support. We will be with you momentarily, please wait up to \`48 hours\`
+
+                            ${MessageUtility.createTipMessage('While you wait, why don\'t you tell us about your query')}
+                            `)
+                            .setTimestamp()
+                    ],
+                    components: [
+                        new ActionRowBuilder<ButtonBuilder>().setComponents(
+                            new ButtonBuilder()
+                                .setCustomId('ticket-lock-button')
+                                .setLabel('Lock Ticket')
+                                .setEmoji('🔐')
+                                .setStyle(ButtonStyle.Secondary),
+                            new ButtonBuilder()
+                                .setCustomId('ticket-close-button')
+                                .setLabel('Close Ticket')
+                                .setEmoji('📁')
+                                .setStyle(ButtonStyle.Danger)
+                        )
+                    ]
+                })
+                await interaction.editReply({
+                    embeds: [
+                        new EmbedBuilder()
+                            .setColor(MessageUtility.embedColourSuccess)
+                            .setAuthor({ name: "Success" })
+                            .setDescription(`
+                            ${MessageUtility.createSuccessMessage("Successfully created your ticket!")}
+
+                            ${MessageUtility.createInfoMessage(`You can find you ticket at ${channelMention(ticketChannel.id)}`)}
+                            `)
+                            .setTimestamp()
+                    ]
+                })
+                return;
+            }
+            case 'ButtonModal': {
+                const createTicketModal = new ModalBuilder()
+                    .setCustomId('ticket-create-modal')
+                    .setTitle('Create a Ticket')
+                    .addComponents(
+                        new ActionRowBuilder<TextInputBuilder>().addComponents(
+                            new TextInputBuilder()
+                                .setCustomId('ticketTopic')
+                                .setLabel('What is the Topic of your support?')
+                                .setPlaceholder('Enter ticket topic/title...')
+                                .setMaxLength(256)
+                                .setStyle(TextInputStyle.Short)
+                                .setRequired(true)
+                        ),
+                        new ActionRowBuilder<TextInputBuilder>().addComponents(
+                            new TextInputBuilder()
+                                .setCustomId('ticketDescription')
+                                .setLabel('Please describe you issue/reason for the support')
+                                .setPlaceholder('Enter ticket description...')
+                                .setMaxLength(1024)
+                                .setStyle(TextInputStyle.Paragraph)
+                                .setRequired(true)
+                        ),
+                        new ActionRowBuilder<TextInputBuilder>().addComponents(
+                            new TextInputBuilder()
+                                .setCustomId('ticketExtraNotes')
+                                .setLabel('Please provide any additional information if applicable')
+                                .setPlaceholder('Enter additional info...')
+                                .setMaxLength(1024)
+                                .setStyle(TextInputStyle.Paragraph)
+                                .setValue('No additional information')
+                                .setRequired(false)
+                        )
+                    )
+
+                await interaction.showModal(createTicketModal);
+
+                return;
+            }
+            default:
+                await interaction.editReply({
+                    embeds: [
+                        new EmbedBuilder()
+                            .setColor(MessageUtility.embedColourError)
+                            .setAuthor({ name: "Error" })
+                            .setDescription(MessageUtility.createErrorMessage(MessageUtility.ErrorMessages.UNKNOWN_ERROR))
+                            .setTimestamp()
+                    ]
+                })
+                return;
+        }
+    }
+}
+
+export default new TicketCreateBtn();

--- a/src/InteractionListeners/Modals/TicketCreateMdl.ts
+++ b/src/InteractionListeners/Modals/TicketCreateMdl.ts
@@ -1,0 +1,119 @@
+import { InteractionListenerType } from "reciple-interaction-events";
+import { BaseModule } from "../../BaseModule.js";
+import { CacheType, channelMention, EmbedBuilder, ModalSubmitInteraction, PermissionFlagsBits } from "discord.js";
+import MessageUtility from "../../Utils/MessageUtility.js";
+import { prisma } from "../../Prisma.js";
+import Helper from "../../Utils/Helper.js";
+
+export class TicketCreateMdl extends BaseModule {
+    public versions: string | string[] = "^8";
+
+    public onStart(): string | boolean | Error | Promise<string | boolean | Error> {
+        this.interactionListeners = [
+            {
+                type: InteractionListenerType.ModalSubmit,
+                customId: "ticket-create-modal",
+                requiredBotPermissions: PermissionFlagsBits.ManageChannels,
+                execute: async (interaction) => {
+                    return await this.HandleExecute(interaction as never as ModalSubmitInteraction<CacheType>)
+                }
+            }
+        ]
+        return true;
+    }
+
+    public async HandleExecute(interaction: ModalSubmitInteraction<CacheType>): Promise<void> {
+        if (!interaction.inCachedGuild()) {
+            await interaction.reply({
+                embeds: [
+                    new EmbedBuilder()
+                        .setColor(MessageUtility.embedColourError)
+                        .setAuthor({ name: "Error" })
+                        .setDescription(MessageUtility.createErrorMessage(MessageUtility.ErrorMessages.NOT_CACHED_GUILD))
+                        .setTimestamp()
+                ]
+            })
+            return;
+        }
+
+        const ticketConfig = await prisma.ticketConfig.findUnique({ where: { guild_id: interaction.guild.id } });
+
+        if (!ticketConfig) {
+            await interaction.editReply({
+                embeds: [
+                    new EmbedBuilder()
+                        .setColor(MessageUtility.embedColourError)
+                        .setAuthor({ name: "Error" })
+                        .setDescription(MessageUtility.createErrorMessage(MessageUtility.ErrorMessages.NO_TICKET_CONFIG))
+                        .setTimestamp()
+                ]
+            })
+            return;
+        }
+
+        if (!ticketConfig.ticket_create_type.includes("Modal")) {
+            await interaction.editReply({
+                embeds: [
+                    new EmbedBuilder()
+                        .setColor(MessageUtility.embedColourError)
+                        .setAuthor({ name: "Error" })
+                        .setDescription(MessageUtility.createErrorMessage(MessageUtility.ErrorMessages.UNKNOWN_ERROR))
+                        .setTimestamp()
+                ]
+            })
+            return;
+        }
+
+        const memberTicket = await prisma.tickets.findFirst({ where: { guild_id: interaction.guild.id, creator_id: interaction.member.id, closed: false } })
+        const memberHasOpenTicket = memberTicket === null ? false : true;
+
+        if (memberHasOpenTicket) {
+            await interaction.editReply({
+                embeds: [
+                    new EmbedBuilder()
+                        .setColor(MessageUtility.embedColourError)
+                        .setAuthor({ name: "Error" })
+                        .setDescription(MessageUtility.createErrorMessage(`You have exceeded the number of open tickets you can have at once. Please first close your ticket at ${channelMention(memberTicket!.ticket_channel_id)}`))
+                        .setTimestamp()
+                ]
+            })
+            return;
+        }
+
+        const ticketTopic = interaction.fields.getTextInputValue('ticketTopic');
+        const ticketDescription = interaction.fields.getTextInputValue('ticketDescription');
+        const ticketExtraNotes = interaction.fields.getTextInputValue('ticketExtraNotes');
+
+        const ticketId = Helper.generateTicketId();
+        const ticketChannel = await Helper.CreateTicketChannel(interaction, ticketConfig, ticketId);
+        await ticketChannel.send({
+            embeds: [
+                new EmbedBuilder()
+                    .setColor(MessageUtility.embedColourDefault)
+                    .setAuthor({ name: interaction.user.username, iconURL: interaction.member.displayAvatarURL() })
+                    .setTitle(`Ticket - ${ticketId}`)
+                    .setDescription(`
+                    Thank you for contacting support. We will be with you momentarily, please wait up to \`48 hours\`
+
+                    ${MessageUtility.createTipMessage('While you wait, why don\'t you tell us a bit more about your query')}
+                    `)
+                    .addFields([
+                        { name: "Topic", value: `${ticketTopic}` },
+                        {
+                            name: "Description",
+                            value: `${ticketDescription}`,
+                            inline: true
+                        },
+                        {
+                            name: "Extra Notes",
+                            value: `${ticketExtraNotes}`,
+                            inline: true,
+                        }
+                    ])
+                    .setTimestamp()
+            ]
+        })
+    }
+}
+
+export default new TicketCreateMdl();

--- a/src/Utils/Helper.ts
+++ b/src/Utils/Helper.ts
@@ -1,4 +1,4 @@
-import { ActionRowBuilder, ButtonInteraction, ChannelType, ChatInputCommandInteraction, ContextMenuCommandInteraction, ModalBuilder, ModalSubmitInteraction, PermissionFlagsBits, TextChannel, TextInputBuilder, TextInputStyle } from "discord.js";
+import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, ChannelType, ChatInputCommandInteraction, ContextMenuCommandInteraction, ModalBuilder, ModalSubmitInteraction, PermissionFlagsBits, TextChannel, TextInputBuilder, TextInputStyle } from "discord.js";
 import { BaseModule } from "../BaseModule.js";
 import Logger from "./Logger.js";
 import { TicketConfig } from "@prisma/client";
@@ -30,7 +30,7 @@ export class Helper extends BaseModule {
                 new ActionRowBuilder<TextInputBuilder>().addComponents(
                     new TextInputBuilder()
                         .setCustomId('ticketDescription')
-                        .setLabel('Please describe you issue/reason for the support')
+                        .setLabel('Please describe your issue/reason')
                         .setPlaceholder('Enter ticket description...')
                         .setMaxLength(1024)
                         .setStyle(TextInputStyle.Paragraph)
@@ -39,7 +39,7 @@ export class Helper extends BaseModule {
                 new ActionRowBuilder<TextInputBuilder>().addComponents(
                     new TextInputBuilder()
                         .setCustomId('ticketExtraNotes')
-                        .setLabel('Please provide any additional information if applicable')
+                        .setLabel('Please provide any additional info if needed')
                         .setPlaceholder('Enter additional info...')
                         .setMaxLength(1024)
                         .setStyle(TextInputStyle.Paragraph)
@@ -54,6 +54,21 @@ export class Helper extends BaseModule {
             Logger.logError(err)
             return;
         }
+    }
+
+    public TicketPanelButtons(): ActionRowBuilder<ButtonBuilder> {
+        return new ActionRowBuilder<ButtonBuilder>().setComponents(
+            new ButtonBuilder()
+                .setCustomId('ticket-lock-button')
+                .setLabel('Lock Ticket')
+                .setEmoji('🔐')
+                .setStyle(ButtonStyle.Secondary),
+            new ButtonBuilder()
+                .setCustomId('ticket-close-button')
+                .setLabel('Close Ticket')
+                .setEmoji('📁')
+                .setStyle(ButtonStyle.Danger)
+        )
     }
 
     public generateTicketId(): string {

--- a/src/Utils/Helper.ts
+++ b/src/Utils/Helper.ts
@@ -1,0 +1,87 @@
+import { ActionRowBuilder, ButtonInteraction, ChannelType, ChatInputCommandInteraction, ContextMenuCommandInteraction, ModalBuilder, ModalSubmitInteraction, PermissionFlagsBits, TextChannel, TextInputBuilder, TextInputStyle } from "discord.js";
+import { BaseModule } from "../BaseModule.js";
+import Logger from "./Logger.js";
+import { TicketConfig } from "@prisma/client";
+
+type ValidInteraction = ChatInputCommandInteraction | ContextMenuCommandInteraction | ButtonInteraction;
+type CachedValidInteraction = ChatInputCommandInteraction<"cached"> | ButtonInteraction<"cached"> | ContextMenuCommandInteraction<"cached">;
+
+export class Helper extends BaseModule {
+    public versions: string | string[] = "^8";
+
+    public onStart(): string | boolean | Error | Promise<string | boolean | Error> {
+        return true;
+    }
+
+    public async ShowCreateTicketModal(interaction: ValidInteraction): Promise<void> {
+        const createTicketModal = new ModalBuilder()
+            .setCustomId('ticket-create-modal')
+            .setTitle('Create a Ticket')
+            .addComponents(
+                new ActionRowBuilder<TextInputBuilder>().addComponents(
+                    new TextInputBuilder()
+                        .setCustomId('ticketTopic')
+                        .setLabel('What is the Topic of your support?')
+                        .setPlaceholder('Enter ticket topic/title...')
+                        .setMaxLength(256)
+                        .setStyle(TextInputStyle.Short)
+                        .setRequired(true)
+                ),
+                new ActionRowBuilder<TextInputBuilder>().addComponents(
+                    new TextInputBuilder()
+                        .setCustomId('ticketDescription')
+                        .setLabel('Please describe you issue/reason for the support')
+                        .setPlaceholder('Enter ticket description...')
+                        .setMaxLength(1024)
+                        .setStyle(TextInputStyle.Paragraph)
+                        .setRequired(true)
+                ),
+                new ActionRowBuilder<TextInputBuilder>().addComponents(
+                    new TextInputBuilder()
+                        .setCustomId('ticketExtraNotes')
+                        .setLabel('Please provide any additional information if applicable')
+                        .setPlaceholder('Enter additional info...')
+                        .setMaxLength(1024)
+                        .setStyle(TextInputStyle.Paragraph)
+                        .setValue('No additional information')
+                        .setRequired(false)
+                )
+            )
+
+        try {
+            await interaction.showModal(createTicketModal)
+        } catch (err) {
+            Logger.logError(err)
+            return;
+        }
+    }
+
+    public generateTicketId(): string {
+        let ticketId = Math.floor(Math.random() * 9999).toString();
+        const zerosNeeded = 4 - ticketId.length;
+        for (let index = zerosNeeded; index > 0; index--) {
+            ticketId = "0" + ticketId
+        }
+        return ticketId;
+    }
+
+    public async CreateTicketChannel(interaction: CachedValidInteraction | ModalSubmitInteraction<"cached">, ticketConfig: TicketConfig, ticketId: string): Promise<TextChannel> {
+        return await interaction.guild.channels.create({
+            name: `${interaction.user.username}-ticket-${ticketId}`,
+            parent: ticketConfig.ticket_parent_channel_id,
+            type: ChannelType.GuildText,
+            permissionOverwrites: [
+                {
+                    id: interaction.guild.roles.everyone.id,
+                    deny: PermissionFlagsBits.ViewChannel
+                },
+                {
+                    id: interaction.member.id,
+                    allow: [PermissionFlagsBits.ViewChannel, PermissionFlagsBits.SendMessages, PermissionFlagsBits.ReadMessageHistory]
+                }
+            ]
+        });
+    }
+}
+
+export default new Helper();

--- a/src/Utils/MessageUtility.ts
+++ b/src/Utils/MessageUtility.ts
@@ -22,7 +22,9 @@ export class MessageUtility extends BaseModule {
 
     public ErrorMessages = {
         DATABASE_ERROR: "Oh no! Something went wrong when trying to edit the data in the database. Please try again later",
-        NOT_CACHED_GUILD: "Oh no! Something went wrong as you are not in a cached guild. Please try again later"
+        NOT_CACHED_GUILD: "Oh no! Something went wrong as you are not in a cached guild. Please try again later",
+        NO_TICKET_CONFIG: "Oh no! Something went wrong as this server does not seem to have configuration data. Please try again later, or, run `/configure system`",
+        UNKNOWN_ERROR: "Oh no! Something unexpected happened which I don't know how to handle. Please try again later",
     }
 
 	public createErrorMessage(message: string): string {


### PR DESCRIPTION
Using the `Button` ticket create type method will create a ticket channel and send a pre-defined embed to the channel alongside the panel buttons.

Using the `ButtonModal` ticket create type method will allow users to enter a modal form where they can describe their ticket in detail before the channel is created. The details are then added to the embed sent to the channel alongside the panel buttons

### ⚠️ Warning ⚠️
The panel buttons do not have support for response interaction handling. This will be added **after** support for the `Command` and `CommandModal` ticket create type methods

### Aditional Notes
This merge tweaked the embeds sent from the `/configure` command where they will return the response with a timestamp